### PR TITLE
Fix the Hessian formula for log-normal AFT loss for interval-censored data

### DIFF
--- a/AFT/py/_aft_loss.py
+++ b/AFT/py/_aft_loss.py
@@ -170,7 +170,7 @@ def _hessian(y_lower, y_higher, y_pred, sigma, event = 'left', dist = 'normal'):
         F_z_l      = _F_z(z_l,dist)
         grad_f_z_u = _grad_f_z(z_u,dist)
         grad_f_z_l = _grad_f_z(z_l,dist) 
-        hess       = ((F_z_u-F_z_l)*(grad_f_z_u+grad_f_z_l)-(f_z_u**2-f_z_l**2))/(sigma**2*(F_z_u-F_z_l)**2)
+        hess       = (-(F_z_u-F_z_l)*(grad_f_z_u-grad_f_z_l)+(f_z_u-f_z_l)**2)/(sigma**2*(F_z_u-F_z_l)**2)
         return hess
     
 


### PR DESCRIPTION
Updated derivation:
![Screen Shot 2019-07-01 at 7 07 33 PM](https://user-images.githubusercontent.com/2532981/60477266-83340380-9c33-11e9-9ef1-e194464067f2.png)

With the fix, the Hessian values for interval-censored data are positive, and we have a convex loss function.

@avinashbarnwal @tdhock